### PR TITLE
Extension streamline enhancements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,54 +56,8 @@
                         <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
                     </configuration>
                 </plugin>
-                <plugin>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.8</version>
-                    <extensions>true</extensions>
-                    <configuration>
-                        <serverId>mavencentral-releases</serverId>
-                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>animal-sniffer-maven-plugin</artifactId>
-                    <version>1.18</version>
-                    <executions>
-                        <execution>
-                            <id>sniff</id>
-                            <phase>test</phase>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <signature>
-                            <groupId>org.codehaus.mojo.signature</groupId>
-                            <artifactId>java18</artifactId>
-                            <version>1.0</version>
-                        </signature>
-                    </configuration>
-                </plugin>
             </plugins>
         </pluginManagement>
-        <plugins>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
     </build>
     <profiles>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
     </scm>
     <distributionManagement>
         <snapshotRepository>
-            <id>mavencentral-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>broadleaf-microservices</id>
+            <url>https://repository.broadleafcommerce.com/repository/microservices/</url>
         </snapshotRepository>
         <repository>
             <id>mavencentral-releases</id>

--- a/pom.xml
+++ b/pom.xml
@@ -34,13 +34,9 @@
         <tag>HEAD</tag>
     </scm>
     <distributionManagement>
-        <snapshotRepository>
+        <repository>
             <id>broadleaf-microservices</id>
             <url>https://repository.broadleafcommerce.com/repository/microservices/</url>
-        </snapshotRepository>
-        <repository>
-            <id>mavencentral-releases</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
     <properties>

--- a/src/main/java/org/broadleafcommerce/frameworkmapping/autoconfigure/FrameworkMappingAutoConfiguration.java
+++ b/src/main/java/org/broadleafcommerce/frameworkmapping/autoconfigure/FrameworkMappingAutoConfiguration.java
@@ -6,8 +6,16 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import java.util.List;
+import java.util.Set;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * Main Boot auto configuration for framework mappings. Referenced in META-INF/spring.factories
@@ -24,4 +32,38 @@ public class FrameworkMappingAutoConfiguration {
     public FrameworkMappingHandlerMapping frameworkControllerHandlerMapping() {
         return new FrameworkMappingHandlerMapping();
     }
+
+    /**
+     * Don't fail a missing path match in the implementation's request mapping if it's available in
+     * the framework mapping
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public WebMvcRegistrations frameworkRequestMappingLenientOverride(FrameworkMappingHandlerMapping frameworkMapping) {
+        return new WebMvcRegistrations() {
+            @Override
+            public RequestMappingHandlerMapping getRequestMappingHandlerMapping() {
+                return new RequestMappingHandlerMapping() {
+
+                    @Override
+                    protected HandlerMethod handleNoMatch(Set<RequestMappingInfo> infos,
+                            String lookupPath,
+                            HttpServletRequest request) throws ServletException {
+                        boolean hasFrameworkMatch;
+                        try {
+                            hasFrameworkMatch = frameworkMapping.getHandler(request) != null;
+                        } catch (Exception e) {
+                            throw new IllegalStateException(e);
+                        }
+                        if (hasFrameworkMatch) {
+                            return null;
+                        }
+                        return super.handleNoMatch(infos, lookupPath, request);
+                    }
+
+                };
+            }
+        };
+    }
+
 }


### PR DESCRIPTION
BroadleafCommerce/MicroPM#3263

- Allow missing mapping for a path to failover to the framework request mapping. This removes the need to re-declare every method for a path.