### PR TITLE
Fix optional trailing slash match regression

### DIFF
--- a/src/main/java/org/broadleafcommerce/frameworkmapping/FrameworkMappingHandlerMapping.java
+++ b/src/main/java/org/broadleafcommerce/frameworkmapping/FrameworkMappingHandlerMapping.java
@@ -24,6 +24,7 @@ import org.springframework.util.ClassUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.handler.AbstractHandlerMethodMapping;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
@@ -98,6 +99,7 @@ public class FrameworkMappingHandlerMapping extends RequestMappingHandlerMapping
 
     @Override
     protected RequestMappingInfo getMappingForMethod(Method method, Class<?> handlerType) {
+        configureMatchOptionalTrailingSeparator();
         RequestMappingInfo requestMappingInfo = createFrameworkRequestMappingInfo(method);
         if (requestMappingInfo != null) {
             RequestMappingInfo typeInfo = createFrameworkRequestMappingInfo(handlerType);
@@ -109,9 +111,16 @@ public class FrameworkMappingHandlerMapping extends RequestMappingHandlerMapping
         return requestMappingInfo;
     }
 
-    @Override
-    public void afterPropertiesSet() {
-        super.afterPropertiesSet();
+    /**
+     * Ideally, this would be configured in {@link #afterPropertiesSet()}. However, the
+     * implementation in the super class does not allow for us to customize the instantiated pattern
+     * parser before the super-super {@link AbstractHandlerMethodMapping#afterPropertiesSet()}
+     * method is called (which creates all the handler methods).
+     * <p>
+     * Thus, we invoke this method at the later stage in
+     * {@link #getMappingForMethod(Method, Class)}.
+     */
+    private void configureMatchOptionalTrailingSeparator() {
         // New approach is to redirect instead of matching trailing slash.
         // However, this can have performance implications. Keeping deprecated approach for now.
         getBuilderConfiguration().getPatternParser().setMatchOptionalTrailingSeparator(true);

--- a/src/main/java/org/broadleafcommerce/frameworkmapping/FrameworkMappingHandlerMapping.java
+++ b/src/main/java/org/broadleafcommerce/frameworkmapping/FrameworkMappingHandlerMapping.java
@@ -115,7 +115,7 @@ public class FrameworkMappingHandlerMapping extends RequestMappingHandlerMapping
      * Ideally, this would be configured in {@link #afterPropertiesSet()}. However, the
      * implementation in the super class does not allow for us to customize the instantiated pattern
      * parser before the super-super {@link AbstractHandlerMethodMapping#afterPropertiesSet()}
-     * method is called (which creates all the handler methods).
+     * method is called (which creates all the handler mappings).
      * <p>
      * Thus, we invoke this method at the later stage in
      * {@link #getMappingForMethod(Method, Class)}.


### PR DESCRIPTION
I found that `ApplicationCatalogFilterIT` in TenantServices started failing because the suggestion I made in https://github.com/BroadleafCommerce/spring-frameworkmapping/pull/9/files/d20806c5da0dc78acd9480b6ff6d7ccbea6a22c6#r1312042219 proved to be wrong.

The way that `afterPropertiesSet()` is implemented doesn't allow us to hook into configuring the pattern parser after it's instantiated but before it's used. Restoring the original behavior.