### PR TITLE
Consolidate on maven.compiler.release property for Java version configuration, update to compiler plugin 3.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <shared.codestyle.directory>${project.build.directory}/shared-codestyle-resources</shared.codestyle.directory>
         <broadleaf.codestyle.version>1.0.1-GA</broadleaf.codestyle.version>
         <maven.flatten.plugin.version>1.2.7</maven.flatten.plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     </properties>
     <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -43,11 +43,8 @@
     </repositories>
     <properties>
         <revision>2.0.0-SNAPSHOT</revision>
-        <java.version>17</java.version>
         <maven.compiler.release>17</maven.compiler.release>
         <resource.delimiter>@</resource.delimiter>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <blc.dependencies>2.9999.0-BRANCH-feature-sb3-SNAPSHOT</blc.dependencies>
@@ -57,10 +54,19 @@
         <shared.codestyle.directory>${project.build.directory}/shared-codestyle-resources</shared.codestyle.directory>
         <broadleaf.codestyle.version>1.0.1-GA</broadleaf.codestyle.version>
         <maven.flatten.plugin.version>1.2.7</maven.flatten.plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     </properties>
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                    <configuration>
+                        <parameters>true</parameters>
+                    </configuration>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
https://github.com/BroadleafCommerce/MicroPM/issues/3870

Tests:
```shell
# Verify compiler release property is set correctly
mvn help:effective-pom | grep -B 4 -A 4 'maven.compiler.release'

# Verify compiler args (only release matters - expect source/target to be defaulted)
mvn -X compile | grep -A 10 -B 10 -E 'release ='

# Verify output class versions
mvn clean package -DskipTests && javap -verbose "$(find . -type f -path '**/target/classes/*.class' | head -1)" | grep major
```