### PR TITLE
Update Spotless Maven Plugin for Java 17 compatibility, engage Spotless automatically on builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,10 +48,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-        <maven.spotless.plugin.version>1.31.3</maven.spotless.plugin.version>
-        <maven.spotless.java.formatter.version>4.13.0</maven.spotless.java.formatter.version>
+        <maven.spotless.plugin.version>2.40.0</maven.spotless.plugin.version>
+        <maven.spotless.java.formatter.version>4.26</maven.spotless.java.formatter.version>
         <shared.codestyle.directory>${project.build.directory}/shared-codestyle-resources</shared.codestyle.directory>
-        <broadleaf.codestyle.version>1.0.1-GA</broadleaf.codestyle.version>
+        <broadleaf.codestyle.version>2.0.0-GA</broadleaf.codestyle.version>
         <maven.flatten.plugin.version>1.2.7</maven.flatten.plugin.version>
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     </properties>
@@ -176,6 +176,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-shared-codestyle-resources</id>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -199,6 +204,10 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
https://github.com/BroadleafCommerce/MicroPM/issues/4238

Cherry-picks work from #12 since it is in `feature-sb3` but not in `develop-2.0.x`


- Update the Spotless Maven plugin to the newest version for Java 17 compatibility
- Also update maven.spotless.java.formatter.version (Eclipse JDT version) to 4.26, matching the default already used by the plugin. Didn't want to rock the boat by removing the property altogether.
- Ensure Spotless check runs automatically on each build